### PR TITLE
various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Put the following lines to your fluent.conf:
       # default: localhost:8088
       server localhost:8088
 
+      # protocol: Connect to Splunk server via 'http' or 'https'
+      # default: https
+      #protocol http
+
       # verify: SSL server verification
       # default: true
       #verify false

--- a/fluent-plugin-splunk-http-eventcollector.gemspec
+++ b/fluent-plugin-splunk-http-eventcollector.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit", '~> 3.1'
   gem.add_runtime_dependency "fluentd", '~> 0.12'
   gem.add_runtime_dependency "net-http-persistent", '~> 2.9'
+  gem.add_runtime_dependency "fluent-mixin-rewrite-tag-name"
 end


### PR DESCRIPTION
- add config param for `protocol` (to support plain http collectors)
- allow config params for `sourcetype` and `source`
- allow `${tag_parts[n]}` interpolation in sourcetype, source, index
