### PR TITLE
Allow to use ${record} as interpolation source

### DIFF
--- a/fluent-plugin-splunk-http-eventcollector.gemspec
+++ b/fluent-plugin-splunk-http-eventcollector.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |gem|
                            "fluent-plugin-splunk-http-eventcollector.gemspec",
                            "lib/fluent/plugin/out_splunk-http-eventcollector.rb",
                            "test/plugin/test_out_splunk-http-eventcollector.rb" ]
-  gem.test_files       = [ "test/helper.rb", 
+  gem.test_files       = [ "test/helper.rb",
                            "test/plugin/test_out_splunk-http-eventcollector.rb" ]
   gem.require_paths    = ["lib"]
 
   gem.add_development_dependency "test-unit", '~> 3.1'
+  gem.add_development_dependency "webmock", '~> 2.3', '>= 2.3.2'
   gem.add_runtime_dependency "fluentd", '~> 0.12'
   gem.add_runtime_dependency "net-http-persistent", '~> 2.9'
-  gem.add_runtime_dependency "fluent-mixin-rewrite-tag-name", '~> 0.1.0'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,6 +22,7 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
+require 'webmock/test_unit'
 require 'fluent/plugin/out_splunk-http-eventcollector'
 
 class Test::Unit::TestCase

--- a/test/plugin/test_out_splunk-http-eventcollector.rb
+++ b/test/plugin/test_out_splunk-http-eventcollector.rb
@@ -18,17 +18,124 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
   def test_configure
     # default
     d = create_driver
-    assert_equal '{TAG}', d.instance.source
-    assert_equal '_json', d.instance.sourcetype
+    assert_equal nil, d.instance.source
+    assert_equal 'fluentd', d.instance.sourcetype
   end
 
   def test_write
+    stub_request(:post, "https://localhost:8089/services/collector").
+      to_return(body: '{"text":"Success","code":0}')
+
     d = create_driver
 
     time = Time.parse("2010-01-02 13:14:15 UTC").to_i
-    d.emit({"a"=>1}, time)
-    d.emit({"a"=>2}, time)
+    d.emit({ "message" => "a message"}, time)
 
     d.run
+
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {
+        "Authorization" => "Splunk changeme",
+        'Content-Type' => 'application/json',
+        'User-Agent' => 'fluent-plugin-splunk-http-eventcollector/0.0.1'
+      },
+      body: { time: time, source:"test", sourcetype: "fluentd", host: "", index: "main", event: "a message" },
+      times: 1
+  end
+
+  def test_expand
+    stub_request(:post, "https://localhost:8089/services/collector").
+      to_return(body: '{"text":"Success","code":0}')
+
+    d = create_driver(CONFIG + %[
+      source ${record["source"]}
+      sourcetype ${tag_parts[0]}
+    ])
+
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    d.emit({"message" => "a message", "source" => "source-from-record"}, time)
+
+    d.run
+
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {"Authorization" => "Splunk changeme"},
+      body: { time: time, source: "source-from-record", sourcetype: "test", host: "", index: "main", event: "a message" },
+      times: 1
+  end
+
+  def test_4XX_error_retry
+    stub_request(:post, "https://localhost:8089/services/collector").
+      with(headers: {"Authorization" => "Splunk changeme"}).
+      to_return(body: '{"text":"Incorrect data format","code":5,"invalid-event-number":0}', status: 400)
+
+    d = create_driver
+
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    d.emit({ "message" => "1" }, time)
+    d.run
+
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {"Authorization" => "Splunk changeme"},
+      body: { time: time, source: "test", sourcetype: "fluentd", host: "", index: "main", event: "1" },
+      times: 1
+  end
+
+  def test_5XX_error_retry
+    request_count = 0
+    stub_request(:post, "https://localhost:8089/services/collector").
+      with(headers: {"Authorization" => "Splunk changeme"}).
+      to_return do |request|
+        request_count += 1
+
+        if request_count < 5
+          { body: '{"text":"Internal server error","code":8}', status: 500 }
+        else
+          { body: '{"text":"Success","code":0}', status: 200 }
+        end
+      end
+
+
+    d = create_driver(CONFIG + %[
+      post_retry_max 5
+      post_retry_interval 0.1
+    ])
+
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    d.emit({ "message" => "1" }, time)
+    d.run
+
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {"Authorization" => "Splunk changeme"},
+      body: { time: time, source: "test", sourcetype: "fluentd", host: "", index: "main", event: "1" },
+      times: 5
+  end
+
+  def test_write_splitting
+    stub_request(:post, "https://localhost:8089/services/collector").
+      with(headers: {"Authorization" => "Splunk changeme"}).
+      to_return(body: '{"text":"Incorrect data format","code":5,"invalid-event-number":0}', status: 400)
+
+    # A single msg is ~110 bytes
+    d = create_driver(CONFIG + %[
+      batch_size_limit 250
+    ])
+
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    d.emit({"message" => "a" }, time)
+    d.emit({"message" => "b" }, time)
+    d.emit({"message" => "c" }, time)
+    d.run
+
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {"Authorization" => "Splunk changeme"},
+      body:
+        { time: time, source: "test", sourcetype: "fluentd", host: "", index: "main", event: "a" }.to_json +
+        { time: time, source: "test", sourcetype: "fluentd", host: "", index: "main", event: "b" }.to_json,
+      times: 1
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {"Authorization" => "Splunk changeme"},
+      body: { time: time, source: "test", sourcetype: "fluentd", host: "", index: "main", event: "c" }.to_json,
+      times: 1
+    assert_requested :post, "https://localhost:8089/services/collector", times: 2
   end
 end


### PR DESCRIPTION
Allow to use ${record} in addition to ${tag_parts} and ${hostname} as
interpolated values for sourcetype, source and index.

Switches from the mixin to the fluent provided expander similar to
https://github.com/kazegusuri/fluent-plugin-prometheus/blob/348c112d/lib/fluent/plugin/prometheus.rb

Added various test to ensure the old values and the new values work.