### PR TITLE
Ability to override time key in Splunk events

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Put the following lines to your fluent.conf:
       # Event Parameters
       #
 
+      # time_key: 'time' parameter passed to Splunk.
+      # default: time
+      #
+      # The "time" key/value will be replaced by an alternate record key you provide.  Useful if
+      # you are using an alternate key to store timestamps with more precision than seconds.
+      time_key time
+
       # host: 'host' parameter passed to Splunk
       host YOUR-HOSTNAME
 
@@ -113,13 +120,13 @@ Put the following lines to your fluent.conf:
       # default: json
       #
       # input = {"x":1, "y":"xyz", "message":"Hello, world!"}
-      # 
+      #
       # 'json' is JSON encoding:
       #   {"x":1,"y":"xyz","message":"Hello, world!"}
-      # 
+      #
       # 'kvp' is "key=value" pairs, which is automatically detected as fields by Splunk:
       #   x="1" y="xyz" message="Hello, world!"
-      # 
+      #
       # 'text' outputs the value of "message" as is, with "key=value" pairs for others:
       #   [x="1" y="xyz"] Hello, world!
       format json
@@ -134,14 +141,14 @@ Put the following lines to your fluent.conf:
       buffer_queue_limit 16
 
       # buffer_chunk_limit: The maxium size of POST data in a single API call.
-      # 
+      #
       # This value should be reasonablly small since the current implementation
       # of out_splunk-http-eventcollector converts a chunk to POST data on memory before API calls.
       # The default value should be good enough.
       buffer_chunk_limit 8m
 
       # flush_interval: The interval of API requests.
-      # 
+      #
       # Make sure that this value is sufficiently large to make successive API calls.
       # Note that a different 'source' creates a different API POST, each of which may
       # take two or more seconds.  If you include "{TAG}" in the source parameter and

--- a/fluent-plugin-splunk-http-eventcollector.gemspec
+++ b/fluent-plugin-splunk-http-eventcollector.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name             = "fluent-plugin-splunk-http-eventcollector"
-  gem.version          = "0.2.0"
+  gem.version          = "0.4.1"
   gem.authors          = ["Bryce Chidester"]
   gem.email            = ["bryce.chidester@calyptix.com"]
   gem.summary          = "Splunk output plugin for Fluentd"

--- a/fluent-plugin-splunk-http-eventcollector.gemspec
+++ b/fluent-plugin-splunk-http-eventcollector.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name             = "fluent-plugin-splunk-http-eventcollector"
-  gem.version          = "0.4.1"
+  gem.version          = "0.4.2"
   gem.authors          = ["Bryce Chidester"]
   gem.email            = ["bryce.chidester@calyptix.com"]
   gem.summary          = "Splunk output plugin for Fluentd"

--- a/fluent-plugin-splunk-http-eventcollector.gemspec
+++ b/fluent-plugin-splunk-http-eventcollector.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit", '~> 3.1'
   gem.add_development_dependency "webmock", '~> 2.3', '>= 2.3.2'
-  gem.add_runtime_dependency "fluentd", '~> 0.12.12'
+  gem.add_runtime_dependency "fluentd", '~> 0.12', '~> 0.12.12'
   gem.add_runtime_dependency "net-http-persistent", '~> 2.9'
 end

--- a/fluent-plugin-splunk-http-eventcollector.gemspec
+++ b/fluent-plugin-splunk-http-eventcollector.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
                            "test/plugin/test_out_splunk-http-eventcollector.rb" ]
   gem.require_paths    = ["lib"]
 
-  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rake", '~> 0'
   gem.add_development_dependency "test-unit", '~> 3.1'
   gem.add_development_dependency "webmock", '~> 2.3', '>= 2.3.2'
   gem.add_runtime_dependency "fluentd", '~> 0.12', '~> 0.12.12'

--- a/lib/fluent/plugin/out_splunk-http-eventcollector.rb
+++ b/lib/fluent/plugin/out_splunk-http-eventcollector.rb
@@ -158,7 +158,7 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     placeholders = @placeholder_expander.prepare_placeholders(placeholder_values)
 
     splunk_object = Hash[
-        "time" => time.to_i,
+        "time" => time.to_f,
         "source" => if @source.nil? then tag.to_s else @placeholder_expander.expand(@source, placeholders) end,
         "sourcetype" => @placeholder_expander.expand(@sourcetype.to_s, placeholders),
         "host" => @placeholder_expander.expand(@host.to_s, placeholders),

--- a/lib/fluent/plugin/out_splunk-http-eventcollector.rb
+++ b/lib/fluent/plugin/out_splunk-http-eventcollector.rb
@@ -171,7 +171,11 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     if @all_items
       splunk_object["event"] = convert_to_utf8(record)
     else
-      splunk_object["event"] = convert_to_utf8(record["message"])
+      if ! record["message"] =~ /^(\s+|\"\"|)$/
+        splunk_object["event"] = convert_to_utf8(record["message"])
+      else
+        exit
+      end
     end
 
     json_event = splunk_object.to_json

--- a/lib/fluent/plugin/out_splunk-http-eventcollector.rb
+++ b/lib/fluent/plugin/out_splunk-http-eventcollector.rb
@@ -110,7 +110,7 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     super
     log.trace "splunk-http-eventcollector(configure) called"
     begin
-      @splunk_uri = URI "#{@protocol}://#{@server}/services/collector"
+      @splunk_uri = URI "#{@protocol}://#{@server}/services/collector/event"
     rescue
       raise ConfigError, "Unable to parse the server into a URI."
     end
@@ -171,11 +171,9 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     if @all_items
       splunk_object["event"] = convert_to_utf8(record)
     else
-      if ! record["message"] =~ /^(\s+|\"\"|)$/
-        splunk_object["event"] = convert_to_utf8(record["message"])
-      else
-        exit
-      end
+#      if ! record["message"] =~ /^(\s+|\"\"|)$/
+      splunk_object["event"] = convert_to_utf8(record["message"])
+#      end
     end
 
     json_event = splunk_object.to_json

--- a/lib/fluent/plugin/out_splunk-http-eventcollector.rb
+++ b/lib/fluent/plugin/out_splunk-http-eventcollector.rb
@@ -42,6 +42,7 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
   config_param :token, :string, :default => nil
 
   # Event parameters
+  config_param :time_key, :string, :default => 'time'
   config_param :protocol, :string, :default => 'https'
   config_param :host, :string, :default => nil
   config_param :index, :string, :default => 'main'
@@ -158,7 +159,7 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     placeholders = @placeholder_expander.prepare_placeholders(placeholder_values)
 
     splunk_object = Hash[
-        "time" => time.to_f,
+        "time" => if record.has_key?(@time_key) then record[@time_key] else time.to_i end,
         "source" => if @source.nil? then tag.to_s else @placeholder_expander.expand(@source, placeholders) end,
         "sourcetype" => @placeholder_expander.expand(@sourcetype.to_s, placeholders),
         "host" => @placeholder_expander.expand(@host.to_s, placeholders),

--- a/lib/fluent/plugin/out_splunk-http-eventcollector.rb
+++ b/lib/fluent/plugin/out_splunk-http-eventcollector.rb
@@ -50,6 +50,7 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
 
   config_param :sourcetype, :string, :default => 'fluentd'
   config_param :source, :string, :default => nil
+  config_param :fields_key, :string, :default => nil
   config_param :post_retry_max, :integer, :default => 5
   config_param :post_retry_interval, :integer, :default => 5
 
@@ -162,6 +163,7 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
         "time" => if record.has_key?(@time_key) then record[@time_key] else time.to_i end,
         "source" => if @source.nil? then tag.to_s else @placeholder_expander.expand(@source, placeholders) end,
         "sourcetype" => @placeholder_expander.expand(@sourcetype.to_s, placeholders),
+        "fields" => if record.has_key?(@fields_key) then record[@fields_key] else Hash.new end,
         "host" => @placeholder_expander.expand(@host.to_s, placeholders),
         "index" =>  @placeholder_expander.expand(@index, placeholders)
       ]
@@ -169,16 +171,12 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     if @all_items
       splunk_object["event"] = convert_to_utf8(record)
     else
-      if record["message"] != ""
-        splunk_object["event"] = convert_to_utf8(record["message"])
-      else
-        log.debug "Suppressing empty message"
-      end
+      splunk_object["event"] = convert_to_utf8(record["message"])
     end
 
     json_event = splunk_object.to_json
-    #log.debug "Generated JSON(#{json_event.class.to_s}): #{json_event.to_s}"
-    #log.debug "format: returning: #{[tag, record].to_json.to_s}"
+      #log.debug "Generated JSON(#{json_event.class.to_s}): #{json_event.to_s}"
+      #log.debug "format: returning: #{[tag, record].to_json.to_s}"
     json_event
   end
 

--- a/lib/fluent/plugin/out_splunk-http-eventcollector.rb
+++ b/lib/fluent/plugin/out_splunk-http-eventcollector.rb
@@ -169,7 +169,11 @@ class SplunkHTTPEventcollectorOutput < BufferedOutput
     if @all_items
       splunk_object["event"] = convert_to_utf8(record)
     else
-      splunk_object["event"] = convert_to_utf8(record["message"])
+      if record["message"] != ""
+        splunk_object["event"] = convert_to_utf8(record["message"])
+      else
+        log.debug "Suppressing empty message"
+      end
     end
 
     json_event = splunk_object.to_json

--- a/test/plugin/test_out_splunk-http-eventcollector.rb
+++ b/test/plugin/test_out_splunk-http-eventcollector.rb
@@ -28,7 +28,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d = create_driver
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({ "message" => "a message"}, time)
 
     d.run
@@ -52,7 +52,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       sourcetype ${tag_parts[0]}
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({"message" => "a message", "source" => "source-from-record"}, time)
 
     d.run
@@ -70,7 +70,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d = create_driver
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({ "message" => "1" }, time)
     d.run
 
@@ -100,7 +100,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       post_retry_interval 0.1
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({ "message" => "1" }, time)
     d.run
 
@@ -120,7 +120,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       batch_size_limit 250
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({"message" => "a" }, time)
     d.emit({"message" => "b" }, time)
     d.emit({"message" => "c" }, time)
@@ -148,7 +148,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       all_items true
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({ "some" => { "nested" => "ü†f-8".force_encoding("BINARY"), "with" => ['ü', '†', 'f-8'].map {|c| c.force_encoding("BINARY") } } }, time)
     d.run
 
@@ -167,7 +167,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       all_items true
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
     d.emit({ "some" => { "nested" => "ü†f-8".force_encoding("BINARY"), "with" => ['ü', '†', 'f-8'].map {|c| c.force_encoding("BINARY") } } }, time)
     d.run
 

--- a/test/plugin/test_out_splunk-http-eventcollector.rb
+++ b/test/plugin/test_out_splunk-http-eventcollector.rb
@@ -23,7 +23,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
   end
 
   def test_write
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       to_return(body: '{"text":"Success","code":0}')
 
     d = create_driver
@@ -33,7 +33,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {
         "Authorization" => "Splunk changeme",
         'Content-Type' => 'application/json',
@@ -44,7 +44,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
   end
 
   def test_empty
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       to_return(body: '{"text":"Success","code":0}')
 
     d = create_driver
@@ -54,7 +54,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d.run
 
-    assert_not_requested :post, "https://localhost:8089/services/collector",
+    assert_not_requested :post, "https://localhost:8089/services/collector/event",
       headers: {
         "Authorization" => "Splunk changeme",
         'Content-Type' => 'application/json',
@@ -65,7 +65,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
   end
 
   def test_expand
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       to_return(body: '{"text":"Success","code":0}')
 
     d = create_driver(CONFIG + %[
@@ -78,14 +78,14 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: time, source: "source-from-record", sourcetype: "test", fields: {}, host: "", index: "main", event: "a message" },
       times: 1
   end
 
   def test_time_override
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       to_return(body: '{"text":"Success","code":0}')
 
     d = create_driver(CONFIG + %[
@@ -99,14 +99,14 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: "1497978619.751919", source: "source-from-record", sourcetype: "test", fields: {}, host: "", index: "main", event: "a message" },
       times: 1
   end
 
   def test_4XX_error_retry
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       with(headers: {"Authorization" => "Splunk changeme"}).
       to_return(body: '{"text":"Incorrect data format","code":5,"invalid-event-number":0}', status: 400)
 
@@ -116,7 +116,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
     d.emit({ "message" => "1" }, time)
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: "1" },
       times: 1
@@ -124,7 +124,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
   def test_5XX_error_retry
     request_count = 0
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       with(headers: {"Authorization" => "Splunk changeme"}).
       to_return do |request|
         request_count += 1
@@ -146,14 +146,14 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
     d.emit({ "message" => "1" }, time)
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: "1" },
       times: 5
   end
 
   def test_write_splitting
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       with(headers: {"Authorization" => "Splunk changeme"}).
       to_return(body: '{"text":"Incorrect data format","code":5,"invalid-event-number":0}', status: 400)
 
@@ -168,21 +168,21 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
     d.emit({"message" => "c" }, time)
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body:
         { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: "a" }.to_json +
         { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: "b" }.to_json,
       times: 1
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: "c" }.to_json,
       times: 1
-    assert_requested :post, "https://localhost:8089/services/collector", times: 2
+    assert_requested :post, "https://localhost:8089/services/collector/event", times: 2
   end
 
   def test_utf8
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       with(headers: {"Authorization" => "Splunk changeme"}).
       to_return(body: '{"text":"Success","code":0}')
 
@@ -194,14 +194,14 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
     d.emit({ "some" => { "nested" => "ü†f-8".force_encoding("BINARY"), "with" => ['ü', '†', 'f-8'].map {|c| c.force_encoding("BINARY") } } }, time)
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: { some: { nested: "     f-8", with: ["  ","   ","f-8"]}}},
       times: 1
   end
 
   def test_utf8
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       with(headers: {"Authorization" => "Splunk changeme"}).
       to_return(body: '{"text":"Success","code":0}')
 
@@ -213,14 +213,14 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
     d.emit({ "some" => { "nested" => "ü†f-8".force_encoding("BINARY"), "with" => ['ü', '†', 'f-8'].map {|c| c.force_encoding("BINARY") } } }, time)
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {"Authorization" => "Splunk changeme"},
       body: { time: time, source: "test", sourcetype: "fluentd", fields: {}, host: "", index: "main", event: { some: { nested: "     f-8", with: ["  ","   ","f-8"]}}},
       times: 1
   end
 
   def test_fields
-    stub_request(:post, "https://localhost:8089/services/collector").
+    stub_request(:post, "https://localhost:8089/services/collector/event").
       to_return(body: '{"text":"Success","code":0}')
 
     d = create_driver(CONFIG + %[
@@ -232,7 +232,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d.run
 
-    assert_requested :post, "https://localhost:8089/services/collector",
+    assert_requested :post, "https://localhost:8089/services/collector/event",
       headers: {
         "Authorization" => "Splunk changeme",
         'Content-Type' => 'application/json',

--- a/test/plugin/test_out_splunk-http-eventcollector.rb
+++ b/test/plugin/test_out_splunk-http-eventcollector.rb
@@ -43,6 +43,27 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       times: 1
   end
 
+  def test_empty
+    stub_request(:post, "https://localhost:8089/services/collector").
+      to_return(body: '{"text":"Success","code":0}')
+
+    d = create_driver
+
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    d.emit({ "message" => ""}, time)
+
+    d.run
+
+    assert_not_requested :post, "https://localhost:8089/services/collector",
+      headers: {
+        "Authorization" => "Splunk changeme",
+        'Content-Type' => 'application/json',
+        'User-Agent' => 'fluent-plugin-splunk-http-eventcollector/0.0.1'
+      },
+      body: { time: time, source:"test", sourcetype: "fluentd", host: "", index: "main", event: "" },
+      times: 1
+  end
+
   def test_expand
     stub_request(:post, "https://localhost:8089/services/collector").
       to_return(body: '{"text":"Success","code":0}')

--- a/test/plugin/test_out_splunk-http-eventcollector.rb
+++ b/test/plugin/test_out_splunk-http-eventcollector.rb
@@ -28,7 +28,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d = create_driver
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({ "message" => "a message"}, time)
 
     d.run
@@ -52,7 +52,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       sourcetype ${tag_parts[0]}
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({"message" => "a message", "source" => "source-from-record"}, time)
 
     d.run
@@ -63,6 +63,27 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       times: 1
   end
 
+  def test_time_override
+    stub_request(:post, "https://localhost:8089/services/collector").
+      to_return(body: '{"text":"Success","code":0}')
+
+    d = create_driver(CONFIG + %[
+      source ${record["source"]}
+      sourcetype ${tag_parts[0]}
+      time_key timestamp
+    ])
+
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
+    d.emit({"message" => "a message", "source" => "source-from-record", "timestamp" => "1497978619.751919"}, time)
+
+    d.run
+
+    assert_requested :post, "https://localhost:8089/services/collector",
+      headers: {"Authorization" => "Splunk changeme"},
+      body: { time: "1497978619.751919", source: "source-from-record", sourcetype: "test", host: "", index: "main", event: "a message" },
+      times: 1
+  end
+
   def test_4XX_error_retry
     stub_request(:post, "https://localhost:8089/services/collector").
       with(headers: {"Authorization" => "Splunk changeme"}).
@@ -70,7 +91,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
 
     d = create_driver
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({ "message" => "1" }, time)
     d.run
 
@@ -100,7 +121,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       post_retry_interval 0.1
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({ "message" => "1" }, time)
     d.run
 
@@ -120,7 +141,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       batch_size_limit 250
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({"message" => "a" }, time)
     d.emit({"message" => "b" }, time)
     d.emit({"message" => "c" }, time)
@@ -148,7 +169,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       all_items true
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({ "some" => { "nested" => "ü†f-8".force_encoding("BINARY"), "with" => ['ü', '†', 'f-8'].map {|c| c.force_encoding("BINARY") } } }, time)
     d.run
 
@@ -167,7 +188,7 @@ class SplunkHTTPEventcollectorOutputTest < Test::Unit::TestCase
       all_items true
     ])
 
-    time = Time.parse("2010-01-02 13:14:15 UTC").to_f
+    time = Time.parse("2010-01-02 13:14:15 UTC").to_i
     d.emit({ "some" => { "nested" => "ü†f-8".force_encoding("BINARY"), "with" => ['ü', '†', 'f-8'].map {|c| c.force_encoding("BINARY") } } }, time)
     d.run
 


### PR DESCRIPTION
This PR adds the ability to specify an alternate key to use for `time` in the Splunk event.

In my particular use case, we require more precision than the default seconds that's native in Fluentd 0.12.  We use `record_reformer` to inject a new field using a more precise timestamp (e.g., `timestamp ${(Time.now.to_f).to_s}`).

This PR allows me to specify `time_key timestamp`, and if present, `timestamp` will be used in lieu of `time` in the Splunk event.  The default value for `time_key` is `time`, and if the specified key isn't present in the record, it falls back to using `time`.
