### PR TITLE
Add support for nested JSON inside message object

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ Put the following lines to your fluent.conf:
       format kvp
     </match>
 
+    # log files containing nested JSON
+    <match **>
+      type splunk-http-eventcollector
+      server splunk.example.com:8089
+      all_items true
+      nested_json true
+    </match>
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
The following code would cause invalid JSON if `message` contains nested JSON: https://github.com/brycied00d/fluent-plugin-splunk-http-eventcollector/blob/master/lib/fluent/plugin/out_splunk-http-eventcollector.rb#L194

This adds opt-in support for the `message` property to contain nested JSON.